### PR TITLE
Add Python 3.6, drop unsupported 2.6, 3.2, 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,13 @@ language: python
 sudo: false
 
 python:
+ - 3.6
  - 3.5
  - 3.4
- - 3.3
- - 3.2
  - 2.7
- - 2.6
  - pypy3
  - pypy
 
 script:
  - python setup.py install
- - if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then 2to3 -w test/test_demjson.py; fi
  - python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,13 @@ for parsing JavaScript data which may not strictly be valid JSON data.
                     "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
                     "Operating System :: OS Independent",
                     "Programming Language :: Python :: 2",
+                    "Programming Language :: Python :: 2.7",
                     "Programming Language :: Python :: 3",
+                    "Programming Language :: Python :: 3.4",
+                    "Programming Language :: Python :: 3.5",
+                    "Programming Language :: Python :: 3.6",
+                    "Programming Language :: Python :: Implementation :: CPython",
+                    "Programming Language :: Python :: Implementation :: PyPy",
                     "Topic :: Software Development :: Libraries :: Python Modules",
                     "Topic :: Internet :: WWW/HTTP :: Dynamic Content"
                     ],

--- a/test/test_demjson.py
+++ b/test/test_demjson.py
@@ -28,13 +28,10 @@ import demjson
 # Python version-specific stuff...
 
 is_python3 = False
-is_python27_plus = False
 try:
     is_python3 = (sys.version_info.major >= 3)
-    is_python27_plus = (sys.version_info.major > 2 or (sys.version_info.major==2 and sys.version_info.minor >= 7))
 except AttributeError:
     is_python3 = (sys.version_info[0] >= 3)
-    is_python27_plus = (sys.version_info[0] > 2 or (sys.version_info[0]==2 and sys.version_info[1] >= 7))
 
 is_wide_python = (sys.maxunicode > 0xFFFF)
 
@@ -55,8 +52,6 @@ if hasattr(unittest, 'skipUnless'):
         return unittest.skipUnless(method, not is_python3)
     def skipUnlessPython3(method):
         return unittest.skipUnless(method, is_python3)
-    def skipUnlessPython27(method):
-        return unittest.skipUnless(method, is_python27_plus)
     def skipUnlessWidePython(method):
         return unittest.skipUnless(method, is_wide_python)
 else:
@@ -68,11 +63,6 @@ else:
     def skipUnlessPython3(method):
         def always_pass(self):
             print("\nSKIPPING TEST %s: Requires Python 3" % method.__name__)
-            return True
-        return always_pass
-    def skipUnlessPython27(method):
-        def always_pass(self):
-            print("\nSKIPPING TEST %s: Requires Python 2.7 or greater" % method.__name__)
             return True
         return always_pass
     def skipUnlessWidePython(method):
@@ -673,7 +663,7 @@ class DemjsonTest(unittest.TestCase):
         self.assertEqual(demjson.decode( rawbytes([ 0xFF, 0xFE, FOUR, 0 ]) ), 4 )
         self.assertRaises(demjson.JSONDecodeError,
                           demjson.decode, rawbytes([ 0xFF, 0xFE, 0, FOUR ]) )
-        
+
         # Invalid Unicode strings
         self.assertRaises(demjson.JSONDecodeError,
                           demjson.decode, rawbytes([ 0 ]) )
@@ -1170,7 +1160,6 @@ class DemjsonTest(unittest.TestCase):
         self.assertEqual(demjson.encode( d, sort_keys=demjson.SORT_SMART ),
                          '{"apple":1,"Ball":1,"cat":1,"dog1":1,"dog002":1,"DOG03":1,"dog10":1}' )
 
-    @skipUnlessPython27
     def testEncodeDictPreserveSorting(self):
         import collections
         d = collections.OrderedDict()
@@ -1509,7 +1498,7 @@ def run_all_tests():
     if int( demjson.__version__.split('.',1)[0] ) < 2:
         print('WARNING: TESTING AGAINST AN OLD VERSION!')
     unittest.main()
-    
+
 if __name__ == '__main__':
     run_all_tests()
 

--- a/test/test_demjson.py
+++ b/test/test_demjson.py
@@ -47,29 +47,12 @@ if is_python3:
 
 # ====================
 
-if hasattr(unittest, 'skipUnless'):
-    def skipUnlessPython2(method):
-        return unittest.skipUnless(method, not is_python3)
-    def skipUnlessPython3(method):
-        return unittest.skipUnless(method, is_python3)
-    def skipUnlessWidePython(method):
-        return unittest.skipUnless(method, is_wide_python)
-else:
-    # Python <= 2.6 does not have skip* decorators, so
-    # just make a dummy decorator that always passes the
-    # test method.
-    def skipUnlessPython2(method):
-        return method
-    def skipUnlessPython3(method):
-        def always_pass(self):
-            print("\nSKIPPING TEST %s: Requires Python 3" % method.__name__)
-            return True
-        return always_pass
-    def skipUnlessWidePython(method):
-        def always_pass(self):
-            print("\nSKIPPING TEST %s: Requires Python with wide Unicode support (maxunicode > U+FFFF)" % method.__name__)
-            return True
-        return always_pass
+def skipUnlessPython2(method):
+    return unittest.skipUnless(method, not is_python3)
+def skipUnlessPython3(method):
+    return unittest.skipUnless(method, is_python3)
+def skipUnlessWidePython(method):
+    return unittest.skipUnless(method, is_wide_python)
 
 ## ------------------------------
 


### PR DESCRIPTION
Only supporting CPython versions which themselves are supported, means we can simplify things a fair bit.

https://en.wikipedia.org/wiki/CPython#Version_history